### PR TITLE
Fix .csprojs

### DIFF
--- a/src/MICore/MICore.csproj
+++ b/src/MICore/MICore.csproj
@@ -55,12 +55,17 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.7.0.4\lib\net20\envdte.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\VSSDK.OLE.Interop.7.0.4\lib\net20\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\VSSDK.Shell.12.12.0.4\lib\net45\Microsoft.VisualStudio.Shell.12.0.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Shell, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Shell.8.8.0.4\lib\net20\Microsoft.VisualStudio.Shell.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -80,8 +85,23 @@
       <HintPath>..\packages\VSSDK.Shell.Interop.9.9.0.4\lib\net20\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.TextManager.Interop.7.0.4\lib\net20\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.TextManager.Interop.8.8.0.4\lib\net20\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.7.0.4\lib\net20\stdole.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Design" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MICore/packages.config
+++ b/src/MICore/packages.config
@@ -1,9 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="VSSDK.DTE" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.10" version="10.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.8" version="8.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.9" version="9.0.4" targetFramework="net45" />
   <package id="VSSDK.OLE.Interop" version="7.0.4" targetFramework="net45" />
-  <package id="VSSDK.Shell.12" version="12.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.8" version="8.0.4" targetFramework="net45" />
   <package id="VSSDK.Shell.Interop" version="7.0.4" targetFramework="net45" />
   <package id="VSSDK.Shell.Interop.10" version="10.0.4" targetFramework="net45" />
   <package id="VSSDK.Shell.Interop.8" version="8.0.4" targetFramework="net45" />
   <package id="VSSDK.Shell.Interop.9" version="9.0.4" targetFramework="net45" />
+  <package id="VSSDK.TextManager.Interop" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.TextManager.Interop.8" version="8.0.4" targetFramework="net45" />
 </packages>

--- a/src/MIDebugEngine/MIDebugEngine.csproj
+++ b/src/MIDebugEngine/MIDebugEngine.csproj
@@ -13,22 +13,6 @@
     <AssemblyName>PistonDevelopers.MIDebugEngine</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -70,6 +54,11 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.7.0.4\lib\net20\envdte.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Debugger.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\VSSDK.Debugger.Interop.10.10.0.4\lib\net40\Microsoft.VisualStudio.Debugger.Interop.10.0.dll</HintPath>
       <Private>False</Private>
@@ -86,8 +75,12 @@
       <HintPath>..\packages\VSSDK.OLE.Interop.7.0.4\lib\net20\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\VSSDK.Shell.12.12.0.4\lib\net45\Microsoft.VisualStudio.Shell.12.0.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Shell.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Shell.10.10.0.4\lib\net40\Microsoft.VisualStudio.Shell.10.0.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\VSSDK.Shell.Immutable.10.10.0.4\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -107,9 +100,28 @@
       <HintPath>..\packages\VSSDK.Shell.Interop.9.9.0.4\lib\net20\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.TextManager.Interop.7.0.4\lib\net20\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSSDK.TextManager.Interop.8.8.0.4\lib\net20\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\packages\VSSDK.DTE.7.0.4\lib\net20\stdole.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AD7.Definitions\AD7Guids.cs" />
@@ -172,6 +184,7 @@
     <ProjectReference Include="..\MICore\MICore.csproj">
       <Project>{12CC862D-95B7-4224-8E16-B928C6333677}</Project>
       <Name>MICore</Name>
+      <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MIDebugEngine/packages.config
+++ b/src/MIDebugEngine/packages.config
@@ -3,10 +3,19 @@
   <package id="VSSDK.Debugger.Interop.10" version="10.0.4" targetFramework="net45" />
   <package id="VSSDK.Debugger.Interop.11" version="11.0.4" targetFramework="net45" />
   <package id="VSSDK.Debugger.Interop.9" version="9.0.4" targetFramework="net45" />
+  <package id="VSSDK.DTE" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.10" version="10.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.11" version="11.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.8" version="8.0.4" targetFramework="net45" />
+  <package id="VSSDK.IDE.9" version="9.0.4" targetFramework="net45" />
   <package id="VSSDK.OLE.Interop" version="7.0.4" targetFramework="net45" />
-  <package id="VSSDK.Shell.12" version="12.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.10" version="10.0.4" targetFramework="net45" />
+  <package id="VSSDK.Shell.Immutable.10" version="10.0.4" targetFramework="net45" />
   <package id="VSSDK.Shell.Interop" version="7.0.4" targetFramework="net45" />
   <package id="VSSDK.Shell.Interop.10" version="10.0.4" targetFramework="net45" />
   <package id="VSSDK.Shell.Interop.8" version="8.0.4" targetFramework="net45" />
   <package id="VSSDK.Shell.Interop.9" version="9.0.4" targetFramework="net45" />
+  <package id="VSSDK.TextManager.Interop" version="7.0.4" targetFramework="net45" />
+  <package id="VSSDK.TextManager.Interop.8" version="8.0.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
As mentioned in PistonDevelopers/VisualRust#173, part of an effort to bring vs2015 compatibility into .csprojs. Supersedes #3 and #4.
Also adds some upstream changes.
